### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clip-Stack
 
-###Deprecated
+### Deprecated
 
 This project is deprecated because of personal reason. 
 
@@ -73,7 +73,7 @@ WRITE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE:  For export clipboard history.
 * [Korean: 준모](https://twitter.com/cns_)
 * [Japanese: 厨二病少女699](http://weibo.com/ikaemon)
 
-###License
+### License
 
 This application is comprised of two parts:
 
@@ -83,43 +83,43 @@ This application is comprised of two parts:
 
 -----
 
-#剪纸堆
+# 剪纸堆
 
-###一个超轻量级剪贴板历史记录管理软件。
+### 一个超轻量级剪贴板历史记录管理软件。
 
 
-####无限保存剪贴板历史
+#### 无限保存剪贴板历史
 
 📌 剪纸堆会自动保留您复制过的每一段文字。就算重启后也会自动恢复。
 
-####易于管理
+#### 易于管理
 
 📌 无论添加、搜索、编辑还是全部清空，都非常容易。而轻轻滑动即可逐条删除。
 
-####有用的扩展通知
+#### 有用的扩展通知
 
 📌 当你可能要输入文字的时候，你最近的6条剪贴板记录会悄悄出现在通知栏上。你能在其中自由切换和粘贴。当不需要时，轻滑即可消去。
 
-####自由分享
+#### 自由分享
 
 📌 每一条剪贴板记录都能分享给其他的程序，诸如 Twitter、Gmail、 Evernote、微信、QQ……
 
-####Material Design
+#### Material Design
 
 📌 不仅图标和颜色，剪纸堆的每一个细节都遵循 Material design 设计标准。尽我可能的利用了 Android 🍭Lollipop 的新特性。
 
-####自动清理
+#### 自动清理
 
 📌 当手机持续出于充电状态几分钟后，剪纸堆会悄悄自动清理自己的缓存数据，和内存占用，——这全归功于 Android 🍭Lollipop 的全新定时任务 API
 
 
-####其他特性
+#### 其他特性
 
 ✓  免费 ✓  开源 ✓  无广告
 
 - 支持 4.0 以上的所有版本 Android 系统，与 Android 5.0🍭Lollipop 最为搭配。
 
-####权限说明
+#### 权限说明
 
 本程序共使用 2 组权限：
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
